### PR TITLE
[PSEUDO] Debug slow speed 

### DIFF
--- a/bench/bench_tinyfk.cpp
+++ b/bench/bench_tinyfk.cpp
@@ -12,11 +12,14 @@ int main(){
     "wrist_roll_link",
     "shoulder_lift_link",
     "upperarm_roll_link"};
+
+  for(int i=0; i<100; i++){
+    link_names.push_back("l_gripper_finger_link");
+  }
   std::cout << "\n start benchmarking" << std::endl; 
 
   auto robot = RobotModel(urdf_file);
   std::vector<std::string> joint_names = {// all joints to drive fetch arm
-        "torso_lift_joint",
         "shoulder_pan_joint",
         "shoulder_lift_joint",
         "upperarm_roll_joint",
@@ -26,18 +29,7 @@ int main(){
         "wrist_roll_joint"};
   auto joint_ids = robot.get_joint_ids(joint_names);
   auto link_ids = robot.get_link_ids(link_names);
-  std::vector<double> angle_vector = {0, 0, 0, 0, 0, 0, 0, 0};
-  {// bench tinyfk FK : without using cache
-    clock_t start = clock();
-    urdf::Pose out;
-    for(int i=0; i<N; i++){
-      for(int lid : link_ids){
-        robot.get_link_point(lid, out, false);
-      }
-    }
-    clock_t end = clock();
-    std::cout << "tinyfk.FK_naive : " << end - start << std::endl;
-  }
+  std::vector<double> angle_vector = {0, 0, 0, 0, 0, 0, 0};
 
   {// bench tinyfk FK : with cache
     clock_t start = clock();
@@ -49,6 +41,6 @@ int main(){
       }
     }
     clock_t end = clock();
-    std::cout << "tinyfk.FK_with_cache : " << end - start << std::endl;
+    std::cout << "tinyfk.FK_with_cache : " << double(end - start)/1e6 << std::endl;
   }
 }

--- a/bench/bench_tinyfk.cpp
+++ b/bench/bench_tinyfk.cpp
@@ -32,14 +32,21 @@ int main(){
   std::vector<double> angle_vector = {0, 0, 0, 0, 0, 0, 0};
 
   {// bench tinyfk FK : with cache
-    clock_t start = clock();
-    urdf::Pose out;
-    for(int i=0; i<N; i++){
-      robot.set_joint_angles(joint_ids, angle_vector); // this clear cached TFs
-      for(int lid : link_ids){
-        robot.get_link_point_withcache(lid, out, false);
-      }
+    std::cout << "N: " << N << std::endl; 
+    std::cout << "joint_ids: ";
+    for(int id : joint_ids){
+      std::cout << id << " ";
     }
+    std::cout << std::endl;
+
+    std::cout << "link_ids: ";
+    for(int id : link_ids){
+      std::cout << id << " ";
+    }
+    std::cout << std::endl;
+
+    clock_t start = clock();
+    robot.debug_loop_get_points(N, joint_ids, angle_vector, link_ids);
     clock_t end = clock();
     std::cout << "tinyfk.FK_with_cache : " << double(end - start)/1e6 << std::endl;
   }

--- a/bench/compare_skrobot.py
+++ b/bench/compare_skrobot.py
@@ -9,10 +9,6 @@ import time
 urdf_path = "../data/fetch_description/fetch.urdf"
 rtree = tinyfk.RobotModel(urdf_path)
 
-link_names = ["shoulder_pan_link", "shoulder_lift_link",
-              "upperarm_roll_link", "elbow_flex_link",
-              "forearm_roll_link", "wrist_flex_link",
-              "wrist_roll_link"]
 elink_names = [
         "l_gripper_finger_link", 
         "r_gripper_finger_link", 

--- a/bench/compare_skrobot.py
+++ b/bench/compare_skrobot.py
@@ -20,6 +20,7 @@ elink_names = [
         "wrist_roll_link",
         "shoulder_lift_link",
         "upperarm_roll_link"];
+elink_names.extend(["l_gripper_finger_link"]*100)
 
 joint_names = [
         "shoulder_pan_joint", 
@@ -32,39 +33,10 @@ joint_names = [
 
 rarm_jids = rtree.get_joint_ids(joint_names)
 elinks = rtree.get_link_ids(elink_names)
-av = [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1] 
-av_seq = [av] * 10
-N_itr = 100
+av = [0.0]*7
+av_seq = [av] * 100000
+N_itr = 1
 
-# bench tinyfk
 ts = time.time()
-for i in range(N_itr):
-    P, J = rtree.solve_forward_kinematics(av_seq, elinks, rarm_jids, False, False, True)
+rtree._solve_forward_kinematics(av_seq, elinks, rarm_jids, False, False, False)
 print("tinyfk jac computation : {0} sec".format(time.time() - ts))
-
-robot_model = skrobot.models.Fetch()
-joint_table = {j.name : j for j in robot_model.joint_list}
-link_table = {l.name : l for l in robot_model.link_list}
-joint_list = [joint_table[name] for name in joint_names]
-link_list = [j.child_link for j in joint_list]
-
-# bench skrobot
-def set_joint_angles(av):
-    return [j.joint_angle(a) for j, a in zip(joint_list, av)]
-
-endcoords_list = [skrobot.coordinates.CascadedCoords(parent=link_table[name]) 
-        for name in elink_names]
-world_coordinate = CascadedCoords()
-
-import time
-ts = time.time()
-for i in range(N_itr):
-    for av in av_seq:
-        set_joint_angles(av)
-        for ec in endcoords_list:
-            J_sk = robot_model.calc_jacobian_from_link_list(
-                    ec,
-                    link_list,
-                    transform_coords=world_coordinate,
-                    rotation_axis=False)
-print("skrobot jac computation : {0} sec".format(time.time() - ts))

--- a/python/wrapper.cpp
+++ b/python/wrapper.cpp
@@ -102,6 +102,10 @@ class RobotModelPyWrapper
       return _rtree.get_link_ids(link_names);
     }
 
+    void add_new_link(std::string link_name, unsigned int parent_id, std::array<double, 3> position){ 
+      _rtree.add_new_link(link_name, parent_id, position);
+    }
+
 };
 
 PYBIND11_MODULE(_tinyfk, m) {
@@ -112,5 +116,6 @@ PYBIND11_MODULE(_tinyfk, m) {
             .def("set_joint_angles", &RobotModelPyWrapper::set_joint_angles)
             .def("get_joint_ids", &RobotModelPyWrapper::get_joint_ids)
             .def("set_base_pose", &RobotModelPyWrapper::set_base_pose)
+            .def("add_new_link", &RobotModelPyWrapper::add_new_link)
             .def("get_link_ids", &RobotModelPyWrapper::get_link_ids);
 }

--- a/python/wrapper.cpp
+++ b/python/wrapper.cpp
@@ -104,15 +104,23 @@ class RobotModelPyWrapper
       std::cout << "n_wp: " << n_wp << std::endl; 
       auto n_joints = joint_ids.size();
 
+      std::cout << "N: " << n_wp << std::endl; 
+      std::cout << "joint_ids: ";
+      for(int id : joint_ids){
+        std::cout << id << " ";
+      }
+      std::cout << std::endl;
+
+      std::cout << "link_ids: ";
+      for(int id : elink_ids){
+        std::cout << id << " ";
+      }
+      std::cout << std::endl;
+
       clock_t start = clock();
       urdf::Pose pose;
       auto av = joint_angles_sequence[0];
-      for(unsigned int i=0; i<n_wp; i++){
-        _rtree.set_joint_angles(joint_ids, av);
-        for(int lid : elink_ids){
-          _rtree.get_link_point_withcache(lid, pose, false);
-        }
-      }
+      _rtree.debug_loop_get_points(n_wp, joint_ids, av, elink_ids);
       clock_t end = clock();
       std::cout << double(end - start)/1e6 << std::endl; 
     }

--- a/src/tinyfk.hpp
+++ b/src/tinyfk.hpp
@@ -186,6 +186,20 @@ class RobotModel
       this->_update_abtable(); // set _abtable
     }
 
+    void debug_loop_get_points(int N, 
+        std::vector<unsigned int> joint_ids,
+        std::vector<double> angle_vector,
+        std::vector<unsigned int> link_ids
+        ){
+      urdf::Pose out;
+      for(int i=0; i<N; i++){
+        this->set_joint_angles(joint_ids, angle_vector); // this clear cached TFs
+        for(int lid : link_ids){
+          this->get_link_point_withcache(lid, out, false);
+        }
+      }
+    }
+
   private:
     void _update_abtable(){
       // this function usually must come in the end of a function


### PR DESCRIPTION
Found a strange speed down when wrapping a function by pybind11. 

Because tinyfk takes advantage of the caching strategy, there should be almost no additional computational load when adding the same link points a lot.

As I expected, in the bench-marking via pure c++, no speed down is observed. However, doing the same thing inside a method `_solve_forward_kinematics` in pybind side, incurs a significant (almost 2x) slow down.

To exclude the possibility that the huge overhead when passing objects between python-side and c++-side, I measured the time inside `_solve_forward_kinematics` but the result doesn't change much. 

### comparison of pure forward kinematics (without jac) at https://github.com/HiroIshida/tinyfk/pull/16/commits/ff74fa327c47981b8bf0b08323bcada95951b2db
pure c++ `bench_tinyfk` : 0.32 sec
_solve_forward_kinematics  : 0.55 sec 
inside _solve_forward_kinematics  : 0.53 sec 

