### PR TITLE
rotation mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ find_package(Eigen3 REQUIRED)
 ADD_DEFINITIONS(-DEIGEN_NO_DEBUG)
 include_directories(${EIGEN3_INCLUDE_DIR})
 
-set(TINYFK_SRC src/tinyfk.cpp src/kinematics.cpp src/naive_kinematics.cpp)
+set(TINYFK_SRC src/tinyfk.cpp src/kinematics.cpp src/naive_kinematics.cpp src/utils.cpp)
 include_directories(src/)
 add_library(tinyfk STATIC ${TINYFK_SRC})
 target_link_libraries(tinyfk urdfdom_model)

--- a/src/tinyfk.hpp
+++ b/src/tinyfk.hpp
@@ -227,11 +227,11 @@ namespace tinyfk
 
       void _solve_forward_kinematics(
           int elink_id, const std::vector<unsigned int>& joint_ids,
-          bool with_rot, bool with_base, TinyMatrix& pose_arr, TinyMatrix& jacobian) const;
+          int rotation_mode, bool with_base, TinyMatrix& pose_arr, TinyMatrix& jacobian) const;
 
       void _solve_batch_forward_kinematics(
           std::vector<unsigned int> elink_ids, const std::vector<unsigned int>& joint_ids,
-          bool with_rot, bool with_base, TinyMatrix& pose_arr, TinyMatrix& jacobian_arr) const;
+          int rotation_mode, bool with_base, TinyMatrix& pose_arr, TinyMatrix& jacobian_arr) const;
 
       void get_link_point_withcache(
           unsigned int link_id, urdf::Pose& out_tf_root_to_ef, 
@@ -299,5 +299,13 @@ namespace tinyfk
         _rptable = rptable;
       }
   };
+
+  enum rotation_mode : int
+  {
+    NO_ROTATION, RPY, YPR, XYZW, WXYZ
+  };
+
+  int rotation_dim(int rotation_mode);
+  void copy_pose_to_arr(const urdf::Pose& pose, TinyMatrix& arr, int rotation_mode);
 
 };//end namespace

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,0 +1,67 @@
+#include "tinyfk.hpp"
+
+namespace tinyfk
+{
+
+  int rotation_dim(int rotation_mode){
+    switch(rotation_mode){
+      case NO_ROTATION:
+        return 0;
+      case RPY:
+        return 3;
+      case YPR:
+        return 3;
+      case XYZW:
+        return 4;
+      case WXYZ:
+        return 4;
+    }
+  }
+
+  void copy_pose_to_arr(const urdf::Pose& pose, TinyMatrix& arr, int rotation_mode)
+  {
+    const urdf::Vector3& pos = pose.position;
+    arr[0] = pos.x;
+    arr[1] = pos.y;
+    arr[2] = pos.z;
+    if(rotation_mode != NO_ROTATION){
+      const urdf::Rotation& rot = pose.rotation;
+      switch(rotation_mode){
+        case RPY:
+          {
+            urdf::Vector3 rpy = rot.getRPY();
+            arr[3] = rpy.x;
+            arr[4] = rpy.y;
+            arr[5] = rpy.z;
+            return;
+          }
+        case YPR:
+          {
+            urdf::Vector3 rpy = rot.getRPY();
+            arr[3] = rpy.z;
+            arr[4] = rpy.y;
+            arr[5] = rpy.x;
+            return;
+          }
+        case XYZW:
+          {
+            arr[3] = rot.x;
+            arr[4] = rot.y;
+            arr[5] = rot.z;
+            arr[6] = rot.w;
+            return;
+          }
+        case WXYZ:
+          {
+            arr[3] = rot.x;
+            arr[4] = rot.y;
+            arr[5] = rot.z;
+            arr[6] = rot.w;
+            return;
+          }
+      }
+    }
+  }
+
+}
+

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -128,11 +128,11 @@ int main(){
   robot.set_base_pose(angle_vector[n_joints], angle_vector[n_joints+1], angle_vector[n_joints+2]);
   robot._tf_cache.clear();
   for(int i=0; i< link_names.size(); i++){ 
-    bool rot_also = false; // rotatio part of the geometric jacobian is not yet checked
+    int rotation_mode = NO_ROTATION;
     int link_id = link_ids[i];
     vector<unsigned int> link_ids_ = {link_id};
-    auto J_numerical = robot.get_jacobian_naive(link_id, joint_ids, rot_also, true);
-    auto tmpo = robot.get_jacobians_withcache(link_ids, joint_ids, rot_also, true);
+    auto J_numerical = robot.get_jacobian_naive(link_id, joint_ids, rotation_mode, true);
+    auto tmpo = robot.get_jacobians_withcache(link_ids, joint_ids, rotation_mode, true);
     auto J_analytical_whole = tmpo[0];
     auto J_analytical_block = J_analytical_whole.block(3*i, 0, 3, 10);
 
@@ -146,6 +146,5 @@ int main(){
     std::cout << "[PASS] jacobian match for link : " << link_names[i] << std::endl; 
   }
   std::cout << "[PASS] fk solve compare" << std::endl; 
-
 
 }


### PR DESCRIPTION
In the c++ side, we can now choose rotation mode (RPY, YPR, ... ), but the rotational jacobian is a geometric jacobian (not rpy-jacobian etc)

In python side, on the other hand, user can choose rotation_mode even about jacobian. 

## TODO
fixbug : dimension of jacobian must be fixed to 3 or 6