### PR TITLE
assert only in debug build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
                   export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/lib/x86_64-linux-gnu/pkgconfig"
                   mkdir build
                   cd build
-                  cmake -DBUILD_PYTHON_INTERFACE=OFF .. -CMAKE_BUILD_TYPE=Debug
+                  cmake -DBUILD_PYTHON_INTERFACE=OFF -DCMAKE_BUILD_TYPE=Debug ..
                   make
 
             - name: Test c++

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
                   export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/lib/x86_64-linux-gnu/pkgconfig"
                   mkdir build
                   cd build
-                  cmake -DBUILD_PYTHON_INTERFACE=OFF .. 
+                  cmake -DBUILD_PYTHON_INTERFACE=OFF .. -CMAKE_BUILD_TYPE=Debug
                   make
 
             - name: Test c++

--- a/src/kinematics.cpp
+++ b/src/kinematics.cpp
@@ -164,9 +164,7 @@ namespace tinyfk
         if(_rptable.isRelevant(jid, elink_id)){
           const urdf::JointSharedPtr& hjoint = _joints[jid];
           unsigned int type = hjoint->type;
-          if(type == urdf::Joint::FIXED){
-              throw std::invalid_argument("fixed type is not accepted");
-          }
+          assert(type!=urdf::Joint::FIXED && "fixed type is not accepted");
           urdf::LinkSharedPtr clink = hjoint->getChildLink(); // rotation of clink and hlink is same. so clink is ok.
 
           urdf::Pose tf_rlink_to_clink;

--- a/src/tinyfk.hpp
+++ b/src/tinyfk.hpp
@@ -13,6 +13,7 @@ tinyfk: https://github.com/HiroIshida/tinyfk
 #include <array>
 #include <stack>
 #include <unordered_map>
+#include <assert.h>
 
 namespace tinyfk
 {
@@ -29,8 +30,7 @@ namespace tinyfk
       _isCachedVec(std::vector<bool>(N_link, false)) {}
 
     void set_cache(unsigned int link_id, const urdf::Pose& tf){
-      bool isAlreadyCached = (_isCachedVec[link_id] == true);
-      if(isAlreadyCached){throw std::invalid_argument("attempt to break cache");}
+      assert(_isCachedVec[link_id] && "attempt to break an existing cache");
       _isCachedVec[link_id] = true;
       _data[link_id] = tf;
     }

--- a/src/tinyfk.hpp
+++ b/src/tinyfk.hpp
@@ -30,7 +30,7 @@ namespace tinyfk
       _isCachedVec(std::vector<bool>(N_link, false)) {}
 
     void set_cache(unsigned int link_id, const urdf::Pose& tf){
-      assert(_isCachedVec[link_id] && "attempt to break an existing cache");
+      assert(!_isCachedVec[link_id] && "attempt to break an existing cache");
       _isCachedVec[link_id] = true;
       _data[link_id] = tf;
     }


### PR DESCRIPTION
to check some "logical" mistake, I used to use std::throw, but actually these logical mistake should be checked by assert which is only checked in debug build. 